### PR TITLE
refactor: 스케쥴링 24시간으로 변경

### DIFF
--- a/crawler/src/main/java/crawler/worker/NoticeCrawler.java
+++ b/crawler/src/main/java/crawler/worker/NoticeCrawler.java
@@ -84,8 +84,7 @@ public class NoticeCrawler implements SchedulingOperation {
 
     @Override
     @Transactional
-    @Scheduled(cron = "0 */15 8-20 * * MON-FRI") // 월요일부터 금요일까지 8시부터 20시까지 15분마다 실행
-//    @Scheduled(fixedDelay = 1000*60)
+    @Scheduled(cron = "0 */15 * * * *") // 24시간 15분 간격 실행 - 2025.03.26 수정
     public void scheduling() {
         try {
             doCrawling();


### PR DESCRIPTION

## #️⃣ Issue Number

N/A

## 📝 요약(Summary)


- 금요일 20:45 이후에 게시글이 업데이트된 경우, 월요일 8시에 크롤링할 때 (N) 태그가 사라져 크롤링되지 않는 문제가 발생  
- 이를 해결하기 위해 기존의 월 ~ 금 08:00~20:45 15분 간격 스케줄을 **매일 24시간 동안 15분 간격 스케줄**로 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



