### PR TITLE
refactor: 이미지 바이트 처리

### DIFF
--- a/api/src/main/java/api/domain/image/converter/ImageConverter.java
+++ b/api/src/main/java/api/domain/image/converter/ImageConverter.java
@@ -7,11 +7,8 @@ import db.domain.image.enums.ImageKind;
 import global.annotation.Converter;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.util.StringUtils;
-import org.springframework.web.multipart.MultipartFile;
 
 @Converter
 @RequiredArgsConstructor
@@ -29,15 +26,11 @@ public class ImageConverter {
             .collect(Collectors.toList());
     }
 
-    public ImageDocument toDocument(MultipartFile multipartFile, ImageKind imageKind,
-        Path imagePath) {
-        String originalFileName = StringUtils.cleanPath(
-            Objects.requireNonNull(multipartFile.getOriginalFilename()));
+    public ImageDocument toDocument(String originalFilename, ImageKind imageKind, Path imagePath) {
         String fileName = imagePath.getFileName().toString();
-
         return ImageDocument.builder()
             .imageUrl(fileUtils.createImageUrl(imagePath))
-            .originalName(FileUtils.getFileOfName(originalFileName))
+            .originalName(FileUtils.getFileOfName(originalFilename))
             .serverName(FileUtils.getFileOfName(fileName))
             .extension(FileUtils.getExtension(fileName))
             .imageKind(imageKind)


### PR DESCRIPTION

## #️⃣ Issue Number


## 📝 요약(Summary)

- `java.nio.file.NoSuchFileException` 방지를 위해 이미지를 `byte` 처리
- 이미지 확장자가 다른 경우 새로운 이미지로 판단
- 일부 오류 수정
    - `originalName` 필드에 확장자가 포함되는 오류

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



