### PR TITLE
refactor: image byte 처리 제거

### DIFF
--- a/api/src/main/java/api/domain/image/controller/ImageApiController.java
+++ b/api/src/main/java/api/domain/image/controller/ImageApiController.java
@@ -20,12 +20,11 @@ public class ImageApiController {
     private final ImageBusiness imageBusiness;
 
     @PostMapping()
-    public Api<Boolean> uploadImage(
+    public Api<String> uploadImage(
         @RequestPart("image") MultipartFile multipartFile,
         @RequestParam ImageKind imageKind
     ) {
-        imageBusiness.uploadImage(multipartFile, imageKind);
-        return Api.OK(true);
+        return Api.OK(imageBusiness.uploadImage(multipartFile, imageKind));
     }
 
     @DeleteMapping()

--- a/api/src/main/java/api/domain/image/converter/ImageConverter.java
+++ b/api/src/main/java/api/domain/image/converter/ImageConverter.java
@@ -7,8 +7,10 @@ import db.domain.image.enums.ImageKind;
 import global.annotation.Converter;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Converter
 @RequiredArgsConstructor
@@ -26,11 +28,11 @@ public class ImageConverter {
             .collect(Collectors.toList());
     }
 
-    public ImageDocument toDocument(String originalFilename, ImageKind imageKind, Path imagePath) {
+    public ImageDocument toDocument(MultipartFile file, ImageKind imageKind, Path imagePath) {
         String fileName = imagePath.getFileName().toString();
         return ImageDocument.builder()
             .imageUrl(fileUtils.createImageUrl(imagePath))
-            .originalName(FileUtils.getFileOfName(originalFilename))
+            .originalName(FileUtils.getFileOfName(file))
             .serverName(FileUtils.getFileOfName(fileName))
             .extension(FileUtils.getExtension(fileName))
             .imageKind(imageKind)

--- a/api/src/main/java/api/domain/image/service/ImageService.java
+++ b/api/src/main/java/api/domain/image/service/ImageService.java
@@ -6,6 +6,7 @@ import db.domain.image.enums.ImageKind;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,7 +15,8 @@ public class ImageService {
 
     private final ImageMongoRepository imageMongoRepository;
 
-    public void saveImageMetaData(ImageDocument imageDocument) {
+    @Async
+    public void saveImageMetaDataAsync(ImageDocument imageDocument) {
         imageMongoRepository.save(imageDocument);
     }
 

--- a/api/src/main/java/api/domain/image/utils/FileUtils.java
+++ b/api/src/main/java/api/domain/image/utils/FileUtils.java
@@ -2,8 +2,11 @@ package api.domain.image.utils;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
@@ -29,8 +32,19 @@ public class FileUtils {
         return fileName.substring(fileName.lastIndexOf("."));
     }
 
+    // 확장자를 제외한 순수 파일 이름
     public static String getFileOfName(String fileName) {
         return fileName.substring(0, fileName.lastIndexOf("."));
+    }
+
+    // 확장자를 제외한 순수 파일 이름
+    public static String getFileOfName(MultipartFile multipartFile) {
+        String originalFileName = FileUtils.getOriginalFileName(multipartFile);
+        return originalFileName.substring(0, originalFileName.lastIndexOf("."));
+    }
+
+    public static String getOriginalFileName(MultipartFile multipartFile) {
+        return StringUtils.cleanPath(Objects.requireNonNull(multipartFile.getOriginalFilename()));
     }
 
     public String createImageUrl(Path filePath) {


### PR DESCRIPTION

## #️⃣ Issue Number


## 📝 요약(Summary)

- 기존에는 이미지를 메모리에서 byte[]로 처리했으나, 불필요한 오버헤드를 고려해 MultipartFile 형식으로 직접 반환하도록 변경
- 이미지 업로드 후 응답으로 저장된 이미지 URL을 반환하여 클라이언트가 바로 접근할 수 있도록 개선

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 📑 API Spec

| **기능**          |                |
|-----------------|----------------|
| **HTTP Method** |                |
| **URL**         |                |

### Request Body

### Response Body


## 📸스크린샷 (선택)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



